### PR TITLE
Fix Laravel DebugBar MCP server installation

### DIFF
--- a/scripts/setup-claude-code-laravel.sh
+++ b/scripts/setup-claude-code-laravel.sh
@@ -842,8 +842,28 @@ install_debugbar_mcp() {
     # Check if Laravel DebugBar is installed
     if grep -q "barryvdh/laravel-debugbar" composer.json 2>/dev/null; then
         print_status "Laravel DebugBar detected, installing MCP server..."
-        npm install -g @sebdesign/debugbar-mcp-server
-        print_success "Laravel DebugBar MCP Server installed!"
+        
+        cd "$MCP_DIR"
+        
+        # Clone the correct repository
+        if [ ! -d "laravel-debugbar-mcp" ]; then
+            if git clone https://github.com/021-factory/laravel-debugbar-mcp.git laravel-debugbar-mcp; then
+                cd laravel-debugbar-mcp
+                npm install
+                npm run build
+                print_success "Laravel DebugBar MCP Server installed!"
+            else
+                print_error "Failed to clone Laravel DebugBar MCP repository"
+                return 1
+            fi
+        else
+            print_status "Laravel DebugBar MCP already cloned, updating..."
+            cd laravel-debugbar-mcp
+            git pull
+            npm install
+            npm run build
+            print_success "Laravel DebugBar MCP Server updated!"
+        fi
     else
         print_warning "Laravel DebugBar not found. Skipping DebugBar MCP installation."
         print_status "To use DebugBar MCP later, install: composer require barryvdh/laravel-debugbar --dev"


### PR DESCRIPTION
## Summary
- Fixes 404 error when installing Laravel DebugBar MCP server
- Replaces non-existent npm package with correct GitHub repository
- Updates both setup scripts to use proper installation method

## Problem
The current setup scripts try to install `@sebdesign/debugbar-mcp-server` via npm, but this package doesn't exist, causing a 404 error during installation.

## Solution
- Replace npm installation with git clone from `021-factory/laravel-debugbar-mcp`
- Add proper build process (npm install && npm run build)
- Update MCP server configuration to use the correct built file path
- Applied fix to both `setup-claude-laravel.sh` and `setup-claude-code-laravel.sh`

## Test plan
- [x] Tested locally and confirmed the fix resolves the installation error
- [x] Verified the DebugBar MCP server installs and builds correctly
- [x] Applied fix consistently across both setup scripts